### PR TITLE
release: v0.2.2

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,5 @@
 Release type: patch
 
-Fix npm package build by including missing lib files.
+Fix npm trusted publishing workflow.
 
-- Fix .gitignore to not exclude js/src/lib directory
-- Add missing shiki.ts and utils.ts utility files
+- Add --provenance flag to npm publish for OIDC authentication


### PR DESCRIPTION
Fix npm trusted publishing workflow.

- Add --provenance flag to npm publish for OIDC authentication

Packages:
- @usecross/docs (npm): 0.2.1 → 0.2.2
- cross-docs (PyPI): 0.2.1 → 0.2.2