### PR TITLE
release: v0.2.3

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+Release type: patch
+
+Fix npm OIDC trusted publishing for scoped packages.
+
+- Add publishConfig with provenance in package.json
+- Use Node 24.x for npm publish (workaround for npm CLI bug)
+- Add NPM_CONFIG_PROVENANCE environment variable


### PR DESCRIPTION
Fix npm OIDC trusted publishing for scoped packages.

Based on workaround from [npm/cli#8730](https://github.com/npm/cli/issues/8730):
- Add publishConfig with provenance in package.json
- Use Node 24.x for npm publish
- Add NPM_CONFIG_PROVENANCE environment variable

Packages:
- @usecross/docs (npm): 0.1.0 → 0.2.3
- cross-docs (PyPI): 0.2.2 → 0.2.3