### PR TITLE
release: v0.2.3

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+Release type: patch
+
+Fix release workflow and npm OIDC trusted publishing.
+
+- Simplify workflow to single release job
+- Add publishConfig with provenance in package.json
+- Use Node 24.x for npm publish (workaround for npm CLI bug)
+- Create GitHub release using gh CLI


### PR DESCRIPTION
Fix release workflow and npm OIDC trusted publishing.

- Simplify workflow to single release job
- Add publishConfig with provenance in package.json  
- Use Node 24.x for npm publish (workaround for npm CLI bug)
- Create GitHub release using gh CLI

Packages:
- @usecross/docs (npm): 0.1.0 → 0.2.3
- cross-docs (PyPI): 0.2.2 → 0.2.3