### PR TITLE
Fix npm publishing authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
         run: |
           cd js && npm publish --provenance
         env:
-          NPM_CONFIG_PROVENANCE: true
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Create GitHub release
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary
- Add NODE_AUTH_TOKEN environment variable for npm publishing

The npm publish step was failing because it was missing the authentication token. This adds `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to authenticate with npm.

## Test plan
- [ ] Verify NPM_TOKEN secret is configured in repository settings
- [ ] Merge PR and verify npm publish step succeeds