### PR TITLE
fix: Sync versions to 0.2.3 and auto-commit after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Commit version bumps and remove RELEASE.md
+      - name: Commit version updates
+        if: steps.pypi.outcome == 'success' || steps.npm.outcome == 'success'
+        run: |
+          VERSION=$(jq -r '.version' .autopub/release_info.json)
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add python/cross_docs/__init__.py python/pyproject.toml js/package.json pyproject.toml
+          rm -f RELEASE.md
+          git add RELEASE.md
+          git commit -m "chore: Bump version to ${VERSION} [skip ci]" || echo "No changes to commit"
+          git push
+
       # Fail the workflow if both publishes failed
       - name: Check publish results
         if: steps.pypi.outcome == 'failure' && steps.npm.outcome == 'failure'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,0 @@
----
-release type: patch
----
-
-Test automated release workflow
-
-- Verify full release pipeline works end-to-end
-- Both PyPI and npm publishing with trusted publishing/OIDC

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usecross/docs",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Documentation framework built on Cross-Inertia",
   "type": "module",
   "main": "./dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cross-docs-monorepo"
-version = "0.2.2"
+version = "0.2.3"
 description = "Cross-docs monorepo (not published)"
 
 [tool.autopub]

--- a/python/cross_docs/__init__.py
+++ b/python/cross_docs/__init__.py
@@ -15,7 +15,7 @@ from cross_docs.routes import (
     create_home_route,
 )
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 __all__ = [
     # Config

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cross-docs"
-version = "0.2.2"
+version = "0.2.3"
 description = "Documentation framework built on Cross-Inertia"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
Fix the release workflow to maintain version consistency.

## Changes
- Sync all package versions to 0.2.3 (matching published versions)
- Remove stale RELEASE.md from previous release
- Add workflow step to commit version bumps after successful release

## Why this is needed
The previous release workflow did not commit the version changes back to the repo, causing source files to stay at old versions while packages were published at new versions.