### PR TITLE
fix: Use autopub publish with git plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,14 +110,3 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Commit version updates
-        run: |
-          VERSION=$(jq -r '.version' .autopub/release_info.json)
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add python/cross_docs/__init__.py python/pyproject.toml js/package.json pyproject.toml
-          rm -f RELEASE.md
-          git add RELEASE.md
-          git commit -m "chore: Bump version to ${VERSION} [skip ci]" || echo "No changes to commit"
-          git push

--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,3 @@ htmlcov/
 *.log
 
 # Autopub
-.autopub/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,0 @@
----
-release type: patch
----
-
-Refactor to single CrossDocsPlugin
-
-- Consolidate BunPlugin and UvMonorepoPlugin into CrossDocsPlugin
-- Simplify workflow to use autopub build/publish commands
-- OIDC trusted publishing for both PyPI and npm

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usecross/docs",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Documentation framework built on Cross-Inertia",
   "type": "module",
   "main": "./dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cross-docs-monorepo"
-version = "0.2.4"
+version = "0.2.5"
 description = "Cross-docs monorepo (not published)"
 
 [tool.autopub]

--- a/python/cross_docs/__init__.py
+++ b/python/cross_docs/__init__.py
@@ -15,7 +15,7 @@ from cross_docs.routes import (
     create_home_route,
 )
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 
 __all__ = [
     # Config

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cross-docs"
-version = "0.2.4"
+version = "0.2.5"
 description = "Documentation framework built on Cross-Inertia"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
Fix the release workflow to properly use autopub publish.

## Changes
- Remove `.autopub/` from `.gitignore` so autopub's git plugin works
- Use `autopub publish` which calls our CrossDocsPlugin + handles git commit/push/tag
- Sync versions to 0.2.5 (already published)
- Remove stale RELEASE.md

## How it works now
1. `autopub check` - validates RELEASE.md
2. `autopub prepare` - bumps versions in all files  
3. `autopub build` - calls CrossDocsPlugin.build() (uv build + bun build)
4. `autopub publish` - calls CrossDocsPlugin.publish() (uv publish + npm publish) + git plugin (commit, tag, push)
5. `gh release create` - creates GitHub release