### PR TITLE
Fix workspace build output directory issue

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,19 +2,26 @@
 release type: patch
 ---
 
-# Fix CI build by removing local dependency override
+# Fix CI build issues
 
 ## Summary
 
-This patch fixes the automated release process by removing a local development dependency override that was causing CI builds to fail.
+This patch fixes the automated release process by addressing two issues that were preventing successful builds and publishing.
 
 ## Changes
 
 - Removed local editable path to `cross-inertia` from `website/pyproject.toml`
 - Regenerated `uv.lock` to use the published PyPI version of `cross-inertia` instead
+- Fixed `autopub_bun` plugin to explicitly set build output directory to avoid workspace issues
 
 ## Context
 
-The previous release failed in CI because `website/pyproject.toml` had a `[tool.uv.sources]` override pointing to a local development path (`../../../patrick91/cross-inertia`) that doesn't exist in the CI environment. This caused `uv lock` to fail during the autopub prepare step.
+### Issue 1: Local dependency path
 
-The fix ensures that the published version from PyPI is used in both development and CI environments.
+The first release attempt failed because `website/pyproject.toml` had a `[tool.uv.sources]` override pointing to a local development path (`../../../patrick91/cross-inertia`) that doesn't exist in the CI environment. This caused `uv lock` to fail during the autopub prepare step.
+
+### Issue 2: Workspace build directory
+
+After fixing the local dependency issue, the second release attempt failed during publishing with "No files found to publish". This occurred because `uv build` when run from a workspace member directory (`python/`) outputs to the workspace root `dist/` directory by default, but `uv publish` looks for files in the member's `dist/` directory.
+
+The fix adds `--out-dir dist` to the `uv build` command to ensure files are built in the correct location.

--- a/autopub_bun/__init__.py
+++ b/autopub_bun/__init__.py
@@ -169,8 +169,8 @@ class CrossDocsPlugin(AutopubPlugin, AutopubPackageManagerPlugin):
 
     def build(self) -> None:
         """Build both Python and JS packages."""
-        # Build Python
-        self._run_command(["uv", "build"], cwd=self.python_path)
+        # Build Python with explicit output directory to avoid workspace issues
+        self._run_command(["uv", "build", "--out-dir", "dist"], cwd=self.python_path)
 
         # Build JS
         self._run_command(


### PR DESCRIPTION
Fixes the second autopub CI failure by specifying explicit output directory for uv build.

Changes:
- Modified autopub_bun plugin to use --out-dir dist flag with uv build
- Updated RELEASE.md to document both CI fixes

Fixes: https://github.com/usecross/cross-docs/actions/runs/20269232801

The previous fix (#19) resolved the local dependency issue, but revealed a second issue where uv build in a workspace outputs to the root dist/ directory while uv publish looks in the member's dist/ directory. This adds the --out-dir flag to ensure files are built in the correct location.