### PR TITLE
Update imports for cross-inertia module rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install @usecross/docs
 from pathlib import Path
 from fastapi import FastAPI
 from cross_docs import create_docs_router, strip_trailing_slash_middleware
-from inertia.fastapi import InertiaMiddleware
+from cross_inertia.fastapi import InertiaMiddleware
 
 app = FastAPI()
 app.add_middleware(InertiaMiddleware)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+---
+release type: patch
+---
+
+# Update for cross-inertia module rename
+
+Updates all imports from `inertia` to `cross_inertia` to match the upstream module rename in cross-inertia v0.11.0.
+
+See: https://github.com/usecross/cross-inertia/pull/76

--- a/js/src/components/HomePage.tsx
+++ b/js/src/components/HomePage.tsx
@@ -363,8 +363,18 @@ export function HomeFooter() {
 }
 
 /**
- * Default layout when no children are provided.
+ * Spacer that fills remaining vertical space.
+ * Shows a top border (via gradient) only when it has height.
  */
+function HomeSpacer() {
+  return (
+    <div
+      className="grow"
+      style={{ backgroundImage: 'linear-gradient(rgb(229, 231, 235) 1px, transparent 1px)' }}
+    />
+  )
+}
+
 function DefaultHomeLayout() {
   return (
     <>
@@ -372,6 +382,7 @@ function DefaultHomeLayout() {
       <HomeHero />
       <HomeFeatures />
       <HomeCTA />
+      <HomeSpacer />
       <HomeFooter />
     </>
   )
@@ -417,7 +428,7 @@ export function HomePage({
 
   return (
     <HomePageContext.Provider value={contextValue}>
-      <div className="min-h-screen bg-white">
+      <div className="min-h-screen bg-white flex flex-col">
         <Head title={props.title} />
         {children || <DefaultHomeLayout />}
       </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ requires-python = ">=3.10"
 [tool.uv.workspace]
 members = ["python", "website"]
 
+[tool.uv.sources]
+cross-docs = { workspace = true }
+
 [tool.autopub]
 plugins = [
     "autopub_bun:CrossDocsPlugin",

--- a/python/README.md
+++ b/python/README.md
@@ -20,7 +20,7 @@ from cross_docs import (
     create_docs_handler,
     strip_trailing_slash_middleware,
 )
-from inertia.fastapi import InertiaDep
+from cross_inertia.fastapi import InertiaDep
 
 app = FastAPI()
 app.middleware("http")(strip_trailing_slash_middleware)

--- a/python/cross_docs/routes.py
+++ b/python/cross_docs/routes.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Request
 from fastapi.responses import PlainTextResponse
-from inertia.fastapi import InertiaDep
+from cross_inertia.fastapi import InertiaDep
 
 from .markdown import load_markdown, load_raw_markdown
 from .middleware import wants_markdown

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 dependencies = [
     "fastapi>=0.100.0",
-    "cross-inertia>=0.10.0",
+    "cross-inertia>=0.11.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -82,7 +82,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cross-inertia", specifier = ">=0.10.0" },
+    { name = "cross-inertia", specifier = ">=0.11.0" },
     { name = "fastapi", specifier = ">=0.100.0" },
 ]
 
@@ -115,7 +115,7 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "watchfiles" },
 ]
@@ -123,27 +123,41 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cross-docs", editable = "python" },
-    { name = "cross-inertia", specifier = ">=0.10.0" },
+    { name = "cross-inertia", specifier = ">=0.11.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.100.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "pybun", specifier = ">=1.3.4" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.20.0" },
-    { name = "watchfiles", marker = "extra == 'dev'", specifier = ">=0.20.0" },
 ]
-provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "watchfiles", specifier = ">=0.20.0" }]
 
 [[package]]
 name = "cross-inertia"
-version = "0.11.2"
+version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "httpx" },
     { name = "itsdangerous" },
     { name = "lia-web" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/80/c70a3568f92993aaccc62018ae18acfa6b500139c3afd74c0fe7f1ea9bde/cross_inertia-0.11.2.tar.gz", hash = "sha256:11bc8028ff397f26f2340425974b340c3b47460e1504388b356e36deac5b33f6", size = 2399571, upload-time = "2025-12-11T10:53:48.89Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/3e/0ccd3fadba5890fd0549f3f2d5d980cfdba1b5abb2a184f0274b4e2f76e9/cross_inertia-0.13.0.tar.gz", hash = "sha256:0ed7fc8abe0b6ad084f81d41ff0fa5a707c7af72e2f6fd15e6c22f3b34ab6fa9", size = 2419751, upload-time = "2026-01-02T18:26:41.166Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/1c/27024dd92c5385a84b89562e7bea22925c56593d52009f5ea8a3a5f16308/cross_inertia-0.11.2-py3-none-any.whl", hash = "sha256:d9cc5c58e3472c5509759ec0300a6538ee6acdeb3bee424e94527d096a7955ff", size = 27525, upload-time = "2025-12-11T10:53:47.634Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f8/26c48e7eeb7399ec9db2a98790483d358f2faaff14d2257fcdfefc668b8a/cross_inertia-0.13.0-py3-none-any.whl", hash = "sha256:edf44ac4aad4b8f60f7151708e17246b8b6c504442b83119a168ce808f3b83f7", size = 46006, upload-time = "2026-01-02T18:26:39.795Z" },
+]
+
+[[package]]
+name = "cross-web"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/4f/bdb62e969649ee76d4741ef8eee34384ec2bc21cc66eb7fd244e6ad62be8/cross_web-0.4.0.tar.gz", hash = "sha256:4ae65619ddfcd06d6803432c0366342d7e8aeba10194b4e144d73a662e75370c", size = 157111, upload-time = "2025-12-25T20:45:21.989Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/d6/6c6a036655e5091b26b9f350dcf43821895325aa4727396b14c67679a957/cross_web-0.4.0-py3-none-any.whl", hash = "sha256:0c675bd26e91428cab31e3e927929b42da94aa96da92974e57c78f9a732d0e9b", size = 14200, upload-time = "2025-12-25T20:45:23.075Z" },
 ]
 
 [[package]]
@@ -182,7 +196,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.124.4"
+version = "0.128.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -190,9 +204,9 @@ dependencies = [
     { name = "starlette" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/21/ade3ff6745a82ea8ad88552b4139d27941549e4f19125879f848ac8f3c3d/fastapi-0.124.4.tar.gz", hash = "sha256:0e9422e8d6b797515f33f500309f6e1c98ee4e85563ba0f2debb282df6343763", size = 378460, upload-time = "2025-12-12T15:00:43.891Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", hash = "sha256:1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a", size = 365682, upload-time = "2025-12-27T15:21:13.714Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/57/aa70121b5008f44031be645a61a7c4abc24e0e888ad3fc8fda916f4d188e/fastapi-0.124.4-py3-none-any.whl", hash = "sha256:6d1e703698443ccb89e50abe4893f3c84d9d6689c0cf1ca4fad6d3c15cf69f15", size = 113281, upload-time = "2025-12-12T15:00:42.44Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", hash = "sha256:aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d", size = 103094, upload-time = "2025-12-27T15:21:12.154Z" },
 ]
 
 [package.optional-dependencies]
@@ -201,13 +215,15 @@ standard = [
     { name = "fastapi-cli", extra = ["standard"] },
     { name = "httpx" },
     { name = "jinja2" },
+    { name = "pydantic-extra-types" },
+    { name = "pydantic-settings" },
     { name = "python-multipart" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
 [[package]]
 name = "fastapi-cli"
-version = "0.0.16"
+version = "0.0.20"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "rich-toolkit" },
@@ -215,9 +231,9 @@ dependencies = [
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/75/9407a6b452be4c988feacec9c9d2f58d8f315162a6c7258d5a649d933ebe/fastapi_cli-0.0.16.tar.gz", hash = "sha256:e8a2a1ecf7a4e062e3b2eec63ae34387d1e142d4849181d936b23c4bdfe29073", size = 19447, upload-time = "2025-11-10T19:01:07.856Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/ca/d90fb3bfbcbd6e56c77afd9d114dd6ce8955d8bb90094399d1c70e659e40/fastapi_cli-0.0.20.tar.gz", hash = "sha256:d17c2634f7b96b6b560bc16b0035ed047d523c912011395f49f00a421692bc3a", size = 19786, upload-time = "2025-12-22T17:13:33.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/43/678528c19318394320ee43757648d5e0a8070cf391b31f69d931e5c840d2/fastapi_cli-0.0.16-py3-none-any.whl", hash = "sha256:addcb6d130b5b9c91adbbf3f2947fe115991495fdb442fe3e51b5fc6327df9f4", size = 12312, upload-time = "2025-11-10T19:01:06.728Z" },
+    { url = "https://files.pythonhosted.org/packages/08/89/5c4eef60524d0fd704eb0706885b82cd5623a43396b94e4a5b17d3a3f516/fastapi_cli-0.0.20-py3-none-any.whl", hash = "sha256:e58b6a0038c0b1532b7a0af690656093dee666201b6b19d3c87175b358e9f783", size = 12390, upload-time = "2025-12-22T17:13:31.708Z" },
 ]
 
 [package.optional-dependencies]
@@ -228,7 +244,7 @@ standard = [
 
 [[package]]
 name = "fastapi-cloud-cli"
-version = "0.6.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastar" },
@@ -240,9 +256,9 @@ dependencies = [
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/dd/e5890bb4ee63f9d8988660b755490e346cf5769aaa7f5f3ced9afb9f090a/fastapi_cloud_cli-0.6.0.tar.gz", hash = "sha256:2c333fff2e4b93b9efbec7896ce3ffa3e77ce4cf3d8cb14e35b4f823dfddac02", size = 30579, upload-time = "2025-12-04T15:04:07.008Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/5d/3b33438de35521fab4968b232caa9a4bd568a5078f2b2dfb7bb8a4528603/fastapi_cloud_cli-0.8.0.tar.gz", hash = "sha256:cf07c502528bfd9e6b184776659f05d9212811d76bbec9fbb6bf34bed4c7456f", size = 30257, upload-time = "2025-12-23T12:08:33.904Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/2f/5ba9b5faa75067e30ff48e3c454263ebc2d2301d5509cfefe12cf9fc8156/fastapi_cloud_cli-0.6.0-py3-none-any.whl", hash = "sha256:b654890b5302c90d2f347b123a35186096328838a526316c470b6005cabd4983", size = 23215, upload-time = "2025-12-04T15:04:08.121Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8e/abb95ef59e91bb5adaa2d18fbf9ea70fd524010bb03f406a2dd2a4775ef9/fastapi_cloud_cli-0.8.0-py3-none-any.whl", hash = "sha256:e9f40bee671d985fd25d7a5409b56d4f103777bf8a0c6d746ea5fbf97a8186d9", size = 22306, upload-time = "2025-12-23T12:08:32.68Z" },
 ]
 
 [[package]]
@@ -478,14 +494,14 @@ wheels = [
 
 [[package]]
 name = "lia-web"
-version = "0.2.3"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "cross-web" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/4e/847404ca9d36e3f5468c9e460aed565a02cbca0fdf81247da9f87fabc1b8/lia_web-0.2.3.tar.gz", hash = "sha256:ccc9d24cdc200806ea96a20b22fb68f4759e6becdb901bd36024df7921e848d7", size = 156761, upload-time = "2025-08-11T10:23:21.003Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3d/7d574a7a5cf5fbc5fc09c07ea3696dd400353b7702bc009cf596b8c12035/lia_web-0.3.1.tar.gz", hash = "sha256:7f551269eddd729f1437e9341ad21622a849eb0c0975d9232ccbbaadbdc74c06", size = 2021, upload-time = "2025-12-25T20:41:51.195Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/f2/c68a97c727c795119f1056ad2b7e716c23f26f004292517c435accf90b5c/lia_web-0.2.3-py3-none-any.whl", hash = "sha256:237c779c943cd4341527fc0adfcc3d8068f992ee051f4ef059b8474ee087f641", size = 13965, upload-time = "2025-08-11T10:23:20.215Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/8b/b628fc18658f94b3d094708a18b71083cf47628e85cbc6b9edba54d5b2d7/lia_web-0.3.1-py3-none-any.whl", hash = "sha256:e4e6e7a9381e228aca60a6f3d67dbae9a5f4638eced242d931f95797ddba3f8b", size = 5933, upload-time = "2025-12-25T20:41:52.289Z" },
 ]
 
 [[package]]
@@ -596,14 +612,14 @@ wheels = [
 
 [[package]]
 name = "pybun"
-version = "1.3.4"
+version = "1.3.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/d2/94a80beec151bd130b7e5ab5c01099ee2a818ebee2a50db1e2e8292c5d2a/pybun-1.3.4-py3-none-macosx_12_0_arm64.whl", hash = "sha256:baa6481f6b498ddd0cbcba11891b621d336bdf9dc839f85ead4aa0bb31324569", size = 22118934, upload-time = "2025-12-07T14:07:15.091Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/ea/2e777ff43b4b12781047ec00d3162d933e68993687b7a44fd85e240ca599/pybun-1.3.4-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:ad3ebdf0fba0e1b3838db9c11791744b62d277c3490b3adde4f9190049bad58b", size = 24662316, upload-time = "2025-12-07T14:07:17.684Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/3f/c4958d1852e7dd6c2f69ea9419639962ed3f06560d406823b868ddd281f6/pybun-1.3.4-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:d2e949d723bbdce7822f60400a059ab47a65e6b6c18c30475ba53d2c7b50a41e", size = 39443706, upload-time = "2025-12-07T14:07:20.144Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/a8/bd8aa14d64a5c3c8d55ea5bd30f5c422f6f745a9e4cb0786ed20e469abc3/pybun-1.3.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:157e0936cb0f72888300e98efc6c23fdeee99445e8a9bb1f82d9fca7fc903b6c", size = 37798175, upload-time = "2025-12-07T14:07:22.822Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/4e/ed7df1b93a9af5457e30c07603097b6a1f271b949dfa52374f1887d76527/pybun-1.3.4-py3-none-win_amd64.whl", hash = "sha256:fa7799f571bc4c43d69db5f4808928c9a2e585d2bd987de45a6eb996a62a79b1", size = 41079431, upload-time = "2025-12-07T14:07:25.551Z" },
+    { url = "https://files.pythonhosted.org/packages/57/20/92ed23e766f6eaf2a83faf854903440d536ded67fab50bfe69de68b02690/pybun-1.3.5-py3-none-macosx_12_0_arm64.whl", hash = "sha256:68c09efd7356570fa47370f5ce8fc68f5ed34045b85cbf6e9288cbd856964d7e", size = 22120617, upload-time = "2025-12-18T14:08:37.984Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/fd/042c29d7ce4fc8102eb50db56c94d5ec7c6a5433b6be641f6d3a795ba934/pybun-1.3.5-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:212994afed996704dc8c62ad70075fbf648c3642f9532af4e36f3e752af7a70e", size = 24662645, upload-time = "2025-12-18T14:08:40.79Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/23/492eb1634a8f8e8fc73c02c40c516d2d3d90947d2adb77b3f2bc3489de09/pybun-1.3.5-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:19007bb51acc66cfc13c29386f76c102bf5ad72a07da4a2898803838438adb6c", size = 39451301, upload-time = "2025-12-18T14:08:43.352Z" },
+    { url = "https://files.pythonhosted.org/packages/68/00/a7699d8da53983a27052d44f9425ed5d9ef6573a8c66e7fb59f3f4ee22a4/pybun-1.3.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:49295d16f4c3946d60f665d07b5fe2c76834a70c943b67540e3ccbdb98ba40f2", size = 37800736, upload-time = "2025-12-18T14:08:45.867Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f5/471d3cdcff047a5cd517a37eb25a112c5e1e7502b5807abc65e838d93aec/pybun-1.3.5-py3-none-win_amd64.whl", hash = "sha256:4df60afd07eff9509987add20db3f5a962bfa85af71247bf55f2dc6ab4581162", size = 41092715, upload-time = "2025-12-18T14:08:48.86Z" },
 ]
 
 [[package]]
@@ -745,6 +761,33 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-extra-types"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/35/2fee58b1316a73e025728583d3b1447218a97e621933fc776fb8c0f2ebdd/pydantic_extra_types-2.11.0.tar.gz", hash = "sha256:4e9991959d045b75feb775683437a97991d02c138e00b59176571db9ce634f0e", size = 157226, upload-time = "2025-12-31T16:18:27.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/17/fabd56da47096d240dd45ba627bead0333b0cf0ee8ada9bec579287dadf3/pydantic_extra_types-2.11.0-py3-none-any.whl", hash = "sha256:84b864d250a0fc62535b7ec591e36f2c5b4d1325fa0017eb8cda9aeb63b374a6", size = 74296, upload-time = "2025-12-31T16:18:26.38Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -764,11 +807,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.20"
+version = "0.0.21"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/96/804520d0850c7db98e5ccb70282e29208723f0964e88ffd9d0da2f52ea09/python_multipart-0.0.21.tar.gz", hash = "sha256:7137ebd4d3bbf70ea1622998f902b97a29434a9e8dc40eb203bbcf7c2a2cba92", size = 37196, upload-time = "2025-12-17T09:24:22.446Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/76/03af049af4dcee5d27442f71b6924f01f3efb5d2bd34f23fcd563f2cc5f5/python_multipart-0.0.21-py3-none-any.whl", hash = "sha256:cf7a6713e01c87aa35387f4774e812c4361150938d20d232800f75ffcf266090", size = 24541, upload-time = "2025-12-17T09:24:21.153Z" },
 ]
 
 [[package]]
@@ -850,16 +893,16 @@ wheels = [
 
 [[package]]
 name = "rich-toolkit"
-version = "0.17.0"
+version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/d0/8f8de36e1abf8339b497ce700dd7251ca465ffca4a1976969b0eaeb596fb/rich_toolkit-0.17.0.tar.gz", hash = "sha256:17ca7a32e613001aa0945ddea27a246f6de01dfc4c12403254c057a8ee542977", size = 187955, upload-time = "2025-11-27T11:10:24.863Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/09/3f9b8d9daaf235195c626f21e03604c05b987404ee3bcacee0c1f67f2a8e/rich_toolkit-0.17.1.tar.gz", hash = "sha256:5af54df8d1dd9c8530e462e1bdcaed625c9b49f5a55b035aa0ba1c17bdb87c9a", size = 187925, upload-time = "2025-12-17T10:49:22.583Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/42/ef2ed40699567661d03b0b511ac46cf6cee736de8f3666819c12d6d20696/rich_toolkit-0.17.0-py3-none-any.whl", hash = "sha256:06fb47a5c5259d6b480287cd38aff5f551b6e1a307f90ed592453dd360e4e71e", size = 31412, upload-time = "2025-11-27T11:10:23.847Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/7b/15e55fa8a76d0d41bf34d965af78acdaf80a315907adb30de8b63c272694/rich_toolkit-0.17.1-py3-none-any.whl", hash = "sha256:96d24bb921ecd225ffce7c526a9149e74006410c05e6d405bd74ffd54d5631ed", size = 31412, upload-time = "2025-12-17T10:49:21.793Z" },
 ]
 
 [[package]]
@@ -985,15 +1028,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.47.0"
+version = "2.48.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/2a/d225cbf87b6c8ecce5664db7bcecb82c317e448e3b24a2dcdaacb18ca9a7/sentry_sdk-2.47.0.tar.gz", hash = "sha256:8218891d5e41b4ea8d61d2aed62ed10c80e39d9f2959d6f939efbf056857e050", size = 381895, upload-time = "2025-12-03T14:06:36.846Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/f0/0e9dc590513d5e742d7799e2038df3a05167cba084c6ca4f3cdd75b55164/sentry_sdk-2.48.0.tar.gz", hash = "sha256:5213190977ff7fdff8a58b722fb807f8d5524a80488626ebeda1b5676c0c1473", size = 384828, upload-time = "2025-12-16T14:55:41.722Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/ac/d6286ea0d49e7b58847faf67b00e56bb4ba3d525281e2ac306e1f1f353da/sentry_sdk-2.47.0-py2.py3-none-any.whl", hash = "sha256:d72f8c61025b7d1d9e52510d03a6247b280094a327dd900d987717a4fce93412", size = 411088, upload-time = "2025-12-03T14:06:35.374Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/19/8d77f9992e5cbfcaa9133c3bf63b4fbbb051248802e1e803fed5c552fbb2/sentry_sdk-2.48.0-py2.py3-none-any.whl", hash = "sha256:6b12ac256769d41825d9b7518444e57fa35b5642df4c7c5e322af4d2c8721172", size = 414555, upload-time = "2025-12-16T14:55:40.152Z" },
 ]
 
 [[package]]
@@ -1069,7 +1112,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.20.0"
+version = "0.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1077,9 +1120,9 @@ dependencies = [
     { name = "shellingham" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/28/7c85c8032b91dbe79725b6f17d2fffc595dff06a35c7a30a37bef73a1ab4/typer-0.20.0.tar.gz", hash = "sha256:1aaf6494031793e4876fb0bacfa6a912b551cf43c1e63c800df8b1a866720c37", size = 106492, upload-time = "2025-10-20T17:03:49.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/30/ff9ede605e3bd086b4dd842499814e128500621f7951ca1e5ce84bbf61b1/typer-0.21.0.tar.gz", hash = "sha256:c87c0d2b6eee3b49c5c64649ec92425492c14488096dfbc8a0c2799b2f6f9c53", size = 106781, upload-time = "2025-12-25T09:54:53.651Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/64/7713ffe4b5983314e9d436a90d5bd4f63b6054e2aca783a3cfc44cb95bbf/typer-0.20.0-py3-none-any.whl", hash = "sha256:5b463df6793ec1dca6213a3cf4c0f03bc6e322ac5e16e13ddd622a889489784a", size = 47028, upload-time = "2025-10-20T17:03:47.617Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/e4/5ebc1899d31d2b1601b32d21cfb4bba022ae6fce323d365f0448031b1660/typer-0.21.0-py3-none-any.whl", hash = "sha256:c79c01ca6b30af9fd48284058a7056ba0d3bf5cf10d0ff3d0c5b11b68c258ac6", size = 47109, upload-time = "2025-12-25T09:54:51.918Z" },
 ]
 
 [[package]]
@@ -1114,16 +1157,16 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.38.0"
+version = "0.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/ce/f06b84e2697fef4688ca63bdb2fdf113ca0a3be33f94488f2cadb690b0cf/uvicorn-0.38.0.tar.gz", hash = "sha256:fd97093bdd120a2609fc0d3afe931d4d4ad688b6e75f0f929fde1bc36fe0e91d", size = 80605, upload-time = "2025-10-18T13:46:44.63Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/d9/d88e73ca598f4f6ff671fb5fde8a32925c2e08a637303a1d12883c7305fa/uvicorn-0.38.0-py3-none-any.whl", hash = "sha256:48c0afd214ceb59340075b4a052ea1ee91c16fbc2a9b1469cca0e54566977b02", size = 68109, upload-time = "2025-10-18T13:46:42.958Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
 ]
 
 [package.optional-dependencies]

--- a/website/app.py
+++ b/website/app.py
@@ -5,8 +5,11 @@ from pathlib import Path
 from cross_docs import CrossDocs
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
-from inertia.fastapi import InertiaMiddleware
-from inertia.fastapi.experimental import inertia_lifespan
+from cross_inertia import configure_inertia
+from cross_inertia.fastapi import InertiaMiddleware
+from cross_inertia.fastapi.experimental import inertia_lifespan
+
+configure_inertia(vite_entry="app.tsx")
 
 app = FastAPI(
     title="Cross-Docs",

--- a/website/content/docs/quick-start.md
+++ b/website/content/docs/quick-start.md
@@ -17,7 +17,7 @@ Set up a FastAPI application with Cross-Docs:
 from pathlib import Path
 from fastapi import FastAPI
 from cross_docs import create_docs_router
-from inertia.fastapi import InertiaMiddleware
+from cross_inertia.fastapi import InertiaMiddleware
 
 # Use docs_url to avoid conflict with cross-docs at /docs
 app = FastAPI(docs_url="/api/docs", redoc_url="/api/redoc")

--- a/website/pyproject.toml
+++ b/website/pyproject.toml
@@ -6,20 +6,20 @@ requires-python = ">=3.10"
 dependencies = [
     "fastapi[standard]>=0.100.0",
     "uvicorn[standard]>=0.20.0",
-    "cross-inertia>=0.10.0",
-    "cross-docs",
+    "cross-inertia>=0.11.0",
+    "cross-docs>=0.3.0",
     "httpx>=0.28.1",
     "jinja2>=3.1.6",
     "pybun>=1.3.4",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "watchfiles>=0.20.0",
 ]
 
-[tool.uv.sources]
-cross-docs = { workspace = true }
+# cross-docs is in main dependencies, uses PyPI by default.
+# For local dev, run: uv pip install -e ../python
 
 [tool.cross-docs]
 content_dir = "content"


### PR DESCRIPTION
## Summary

- Updates all imports from `inertia` to `cross_inertia` to match the upstream module rename in cross-inertia

This follows the breaking change in https://github.com/usecross/cross-inertia/pull/76 where the Python module was renamed from `inertia` to `cross_inertia`.

## Test plan

- [ ] Verify the website still runs with `uv run fastapi dev app.py`