### PR TITLE
fix: Use pybun instead of bun for SSR command

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+---
+release type: patch
+---
+
+Fix SSR command to use pybun instead of bun
+
+- Use `sys.executable -m pybun` for the SSR command so it works in production environments where `bun` is not on PATH
+- Add `pybun>=1.0.0` as a dependency

--- a/python/cross_docs/routes.py
+++ b/python/cross_docs/routes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -102,7 +103,7 @@ class CrossDocs:
         configure_inertia(
             vite_entry="app.tsx",
             ssr_enabled=True,
-            ssr_command="bun static/build/ssr/ssr.js",
+            ssr_command=[sys.executable, "-m", "pybun", "static/build/ssr/ssr.js"],
             template_dir="templates",
             manifest_path="static/build/.vite/manifest.json",
         )

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 dependencies = [
     "fastapi>=0.100.0",
     "cross-inertia>=0.11.0",
+    "pybun>=1.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Use sys.executable -m pybun for the SSR command instead of bun directly
- Add pybun>=1.0.0 as a dependency
- Fixes production crash where bun is not on PATH (exit code 127)

## Context

The zero-config SSR feature added in #48 hardcoded bun as the SSR command, but production Python environments (e.g. Docker) don't have bun installed globally. pybun is a Python package that bundles the bun binary, so using sys.executable -m pybun ensures it works wherever the Python app runs.

## Test plan

- [ ] Deploy to production and verify SSR works without bun on PATH
- [ ] Verify view-source shows pre-rendered HTML