### PR TITLE
Add /llms.txt endpoint for AI agent discovery

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,17 @@
+---
+release type: minor
+---
+
+# Add /llms.txt endpoint for AI agent discovery
+
+Cross-docs now auto-generates a `/llms.txt` endpoint from your documentation's navigation structure, following the [llms.txt convention](https://llmstxt.org/). This gives LLM agents a lightweight index of all available pages without bloating individual page responses.
+
+Additionally, markdown responses (served to AI user agents) now include a small footer linking to `/llms.txt` so agents can discover other pages.
+
+## What's new
+
+- **`/llms.txt` route**: Auto-generated from your nav structure. Includes project title, description, and all doc pages organized by section. Works with both single-docs and multi-docs modes.
+- **Markdown response footer**: Each page served as markdown now ends with a link to `/llms.txt` for discoverability.
+- **`generate_llms_txt()` utility**: New public function to render any nav structure as llms.txt content.
+
+The `/llms.txt` route is enabled automatically when `enable_markdown_response` is `True` (the default).

--- a/python/cross_docs/__init__.py
+++ b/python/cross_docs/__init__.py
@@ -13,7 +13,7 @@ from cross_docs.config import (
 )
 from cross_docs.markdown import load_markdown, load_raw_markdown, parse_frontmatter
 from cross_docs.middleware import strip_trailing_slash_middleware, wants_markdown
-from cross_docs.navigation import generate_nav
+from cross_docs.navigation import generate_llms_txt, generate_nav
 from cross_docs.routes import CrossDocs
 
 __version__ = "0.13.1"
@@ -32,6 +32,7 @@ __all__ = [
     "load_markdown",
     "load_raw_markdown",
     # Navigation
+    "generate_llms_txt",
     "generate_nav",
     # Middleware
     "strip_trailing_slash_middleware",

--- a/python/cross_docs/navigation.py
+++ b/python/cross_docs/navigation.py
@@ -1,5 +1,7 @@
 """Navigation generation for cross-docs."""
 
+from __future__ import annotations
+
 from pathlib import Path
 
 from .markdown import parse_frontmatter
@@ -74,3 +76,41 @@ def generate_nav(
             nav.append({"title": section_name, "items": items})
 
     return nav
+
+
+def generate_llms_txt(
+    nav: list[dict],
+    *,
+    title: str = "Documentation",
+    description: str = "",
+    base_url: str = "",
+) -> str:
+    """Generate llms.txt content from a navigation structure.
+
+    Renders the nav as a markdown index following the llms.txt convention
+    (see https://llmstxt.org/).
+
+    Args:
+        nav: Navigation structure from generate_nav()
+        title: Site/project title for the H1 heading
+        description: Short project description (rendered as blockquote)
+        base_url: Base URL to prepend to hrefs (e.g. "https://example.com")
+
+    Returns:
+        llms.txt content as a string
+    """
+    lines = [f"# {title}", ""]
+
+    if description:
+        lines.append(f"> {description}")
+        lines.append("")
+
+    for section in nav:
+        lines.append(f"## {section['title']}")
+        lines.append("")
+        for item in section.get("items", []):
+            href = f"{base_url}{item['href']}"
+            lines.append(f"- [{item['title']}]({href})")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/python/cross_docs/routes.py
+++ b/python/cross_docs/routes.py
@@ -192,11 +192,17 @@ class CrossDocs:
         return PlainTextResponse(raw + footer, media_type="text/markdown")
 
     def _add_llms_txt_route(self) -> None:
-        """Add the /llms.txt route."""
-        router = self._router
-        assert router is not None
+        """Add the /llms.txt route at the root, regardless of docs prefix."""
+        assert self._router is not None
 
-        @router.get("/llms.txt", tags=["llms"], include_in_schema=False)
+        # If the router has a prefix (e.g. /docs), wrap it in a root
+        # router so /llms.txt is always served at the site root.
+        if self._router.prefix:
+            root = APIRouter()
+            root.include_router(self._router)
+            self._router = root
+
+        @self._router.get("/llms.txt", tags=["llms"], include_in_schema=False)
         async def llms_txt():
             """Serve llms.txt for AI agent discovery."""
             return PlainTextResponse(self._get_llms_txt(), media_type="text/markdown")

--- a/python/cross_docs/routes.py
+++ b/python/cross_docs/routes.py
@@ -16,7 +16,7 @@ from cross_inertia.fastapi.experimental import inertia_lifespan
 
 from .markdown import load_markdown, load_raw_markdown
 from .middleware import wants_markdown
-from .navigation import generate_nav
+from .navigation import generate_llms_txt, generate_nav
 
 if TYPE_CHECKING:
     from .config import APIPluginConfig, DocSet, DocsConfig
@@ -150,6 +150,56 @@ class CrossDocs:
             # multi-docs handles this internally for correct route ordering)
             if config.api:
                 self._build_api_routes()
+
+        # Add /llms.txt route if markdown responses are enabled
+        if config.enable_markdown_response:
+            self._add_llms_txt_route()
+
+    def _get_llms_txt(self) -> str:
+        """Generate llms.txt content from current navigation."""
+        config = self.config
+        title = config.home.title or "Documentation"
+        description = config.home.description or ""
+
+        if config.doc_sets and self._nav_by_slug:
+            # Multi-docs: combine all doc set navs
+            lines = [f"# {title}", ""]
+            if description:
+                lines.append(f"> {description}")
+                lines.append("")
+            for doc_set in config.doc_sets:
+                nav = self._nav_by_slug.get(doc_set.slug, [])
+                if not nav:
+                    continue
+                lines.append(f"## {doc_set.name}")
+                lines.append("")
+                for section in nav:
+                    for item in section.get("items", []):
+                        lines.append(f"- [{item['title']}]({item['href']})")
+                lines.append("")
+            return "\n".join(lines)
+
+        return generate_llms_txt(
+            self._nav or [],
+            title=title,
+            description=description,
+        )
+
+    def _markdown_response(self, content_dir: Path, doc_path: str, llms_txt_path: str) -> PlainTextResponse:
+        """Return raw markdown with a footer linking to llms.txt."""
+        raw = load_raw_markdown(content_dir, doc_path)
+        footer = f"\n\n---\n\nFor all available pages, see [{llms_txt_path}]({llms_txt_path})\n"
+        return PlainTextResponse(raw + footer, media_type="text/markdown")
+
+    def _add_llms_txt_route(self) -> None:
+        """Add the /llms.txt route."""
+        router = self._router
+        assert router is not None
+
+        @router.get("/llms.txt", tags=["llms"], include_in_schema=False)
+        async def llms_txt():
+            """Serve llms.txt for AI agent discovery."""
+            return PlainTextResponse(self._get_llms_txt(), media_type="text/markdown")
 
     def _build_single_docs(self) -> None:
         """Build router for single documentation set (original behavior)."""
@@ -329,10 +379,7 @@ class CrossDocs:
 
             # Return raw markdown if requested
             if config.enable_markdown_response and wants_markdown(request):
-                return PlainTextResponse(
-                    load_raw_markdown(content_dir, doc_path),
-                    media_type="text/markdown",
-                )
+                return self._markdown_response(content_dir, doc_path, "/llms.txt")
 
             content = load_markdown(content_dir, doc_path)
             props = {
@@ -384,10 +431,7 @@ class CrossDocs:
 
             # Return raw markdown if requested
             if config.enable_markdown_response and wants_markdown(request):
-                return PlainTextResponse(
-                    load_raw_markdown(content_dir, doc_path),
-                    media_type="text/markdown",
-                )
+                return self._markdown_response(content_dir, doc_path, "/llms.txt")
 
             content = load_markdown(content_dir, doc_path)
             props = {

--- a/python/cross_docs/routes.py
+++ b/python/cross_docs/routes.py
@@ -174,9 +174,11 @@ class CrossDocs:
                 lines.append(f"## {doc_set.name}")
                 lines.append("")
                 for section in nav:
+                    lines.append(f"### {section['title']}")
+                    lines.append("")
                     for item in section.get("items", []):
                         lines.append(f"- [{item['title']}]({item['href']})")
-                lines.append("")
+                    lines.append("")
             return "\n".join(lines)
 
         return generate_llms_txt(


### PR DESCRIPTION
## Summary

- Auto-generates a `/llms.txt` route from the existing nav structure, following the [llms.txt convention](https://llmstxt.org/)
- Adds a one-line footer to markdown page responses linking to `/llms.txt` for discoverability
- Exports `generate_llms_txt()` as a public utility for rendering nav as llms.txt content

## Context

When LLM agents (Claude Code, ChatGPT, etc.) fetch a docs page, they get clean markdown but have no way to discover what other pages exist. The industry pattern is a separate `/llms.txt` index rather than embedding the full nav in every response (which causes context bloat).

## Test plan

- [x] All 78 existing tests pass
- [ ] Verify `/llms.txt` returns correct nav structure in single-docs mode
- [ ] Verify `/llms.txt` returns combined nav in multi-docs mode
- [ ] Verify markdown page responses include the footer
- [ ] Verify `/llms.txt` is not registered when `enable_markdown_response` is `False`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New /llms.txt endpoint auto-generated from documentation to support LLM agent discovery (llms.txt convention).
  * Markdown responses include a footer link to /llms.txt for improved AI agent discoverability.
  * Automatic enabling of the /llms.txt route when markdown response serving is active.
  * Supports multi-doc sites and generates a structured, linkable index from the docs navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->