### PR TITLE
Narrow documentation sidebar

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+---
+release type: patch
+---
+
+Narrow the documentation sidebar
+
+- Reduce the desktop documentation sidebar from 384px to 256px
+- Match the navigation padding used by the API documentation layout
+- Leave more room for documentation content on narrower desktop screens

--- a/js/src/components/DocsLayout.tsx
+++ b/js/src/components/DocsLayout.tsx
@@ -159,11 +159,11 @@ export function DocsLayout({
         <div className="flex">
           {/* Desktop sidebar - fixed width */}
           <aside
-            className="hidden lg:block w-[24rem] shrink-0 border-r border-gray-200 dark:border-gray-800 transition-colors"
+            className="hidden lg:block w-64 shrink-0 border-r border-gray-200 dark:border-gray-800 transition-colors"
             style={{ minHeight: `calc(100vh - ${headerHeight}px)` }}
           >
             <nav
-              className="sticky px-4 lg:px-10 py-6 overflow-y-auto"
+              className="sticky px-6 py-6 overflow-y-auto"
               style={{ top: headerHeight, maxHeight: `calc(100vh - ${headerHeight}px)` }}
             >
               <Sidebar nav={nav} currentPath={currentPath} docSets={docSets} currentDocSet={currentDocSet} />

--- a/js/src/components/DocsLayout.tsx
+++ b/js/src/components/DocsLayout.tsx
@@ -163,7 +163,7 @@ export function DocsLayout({
             style={{ minHeight: `calc(100vh - ${headerHeight}px)` }}
           >
             <nav
-              className="sticky px-6 py-6 overflow-y-auto"
+              className="sticky px-4 lg:px-10 py-6 overflow-y-auto"
               style={{ top: headerHeight, maxHeight: `calc(100vh - ${headerHeight}px)` }}
             >
               <Sidebar nav={nav} currentPath={currentPath} docSets={docSets} currentDocSet={currentDocSet} />


### PR DESCRIPTION
## Summary

- reduce the standard documentation sidebar from 24rem to 16rem
- align its navigation padding with the API documentation layout
- add a patch release note for CrossDocs 0.16.1

## Why

The 24rem sidebar consumes too much horizontal space on narrower desktop screens, leaving the documentation content cramped. The API layout already uses a 16rem sidebar, so this makes the two documentation layouts consistent.

## Validation

- `bun run lint`
- `bun run --cwd js typecheck`
- `bun run --cwd js build`
- `bun run --cwd website build`
- AutoPub release check
- visual verification at the desktop breakpoint: 256px sidebar with no horizontal overflow

## Summary by Sourcery

Narrow the desktop documentation sidebar to align with the API layout and improve content space on narrower screens.

Enhancements:
- Adjust the desktop documentation sidebar width from 24rem to 16rem to reduce horizontal space usage.

Documentation:
- Add a patch release note describing the sidebar width change and its impact on documentation layout.